### PR TITLE
Computation for the stats breakdown

### DIFF
--- a/Main/Controllers/ItemsController.cs
+++ b/Main/Controllers/ItemsController.cs
@@ -34,10 +34,19 @@ namespace SampleProj.Controllers
             };
             AvailableItems[0].Name = "Test_Item_1";
             AvailableItems[0].HealthBonus = 50d;
-            AvailableItems[0].HealthRegenerationBonus = 3.2d;
+            AvailableItems[0].HealthRegenerationBonus = 3.4d;
+            AvailableItems[0].CriticalStrikeChanceBonus = 0.25;
+            AvailableItems[0].AttackSpeedBonus = 0.20;
+            AvailableItems[0].AttackRangeBonus = 75;
+            AvailableItems[0].ArmorBonus = 55;
+            AvailableItems[0].MagicResistanceBonus = 35;
+            AvailableItems[0].LifeStealBonus = 0.12;
+            AvailableItems[0].MovementSpeedBonus = 355;
+
             AvailableItems[1].Name = "Test_Item_2"; 
             AvailableItems[1].HealthBonus = 14d;
-
+            AvailableItems[1].HealthRegenerationBonus = 1.7d;
+            AvailableItems[1].MovementSpeedBonus = 100;
 
 
             AvailableItems[2].Name = "Iron Helm"; 
@@ -60,6 +69,7 @@ namespace SampleProj.Controllers
             ChampStat= new ChampionStat();
             // FOR TESTING PURPOSES
             EquippedItems.Add(AvailableItems[0]);
+            EquippedItems.Add(AvailableItems[1]);
             // FOR TESTING PURPOSES
             ViewBag.availableItems = AvailableItems;
             ViewBag.equippedItems = EquippedItems;
@@ -78,7 +88,15 @@ namespace SampleProj.Controllers
         }
 
 
-        // internal function to calculate the current champion statistic breakdown
+        // calculate_stats modifies the current ChampStat object being
+        // used as the current representation of the champion statistic
+        // computation. First, the stats are cleared (but, the level is kept),
+        // then the bonuses from items are computed in a for loop.
+        // Finally, the new computation of the current statistical representation
+        // is done for each statistic.
+        //
+        // calculate_stats should be called when there are changes to items, or
+        // changes to the champion being looked at.
         private void calculate_stats()
         {
             // Reset ChampStat to the base state.
@@ -114,7 +132,7 @@ namespace SampleProj.Controllers
             double bonus_percent_MR_pen_total = 0d;
             double bonus_percent_AR_pen_total = 0d;
             double bonus_ability_haste_total = 0d;
-            int bonus_gold_generation = 0;
+            int bonus_gold_generation_total = 0;
 
             // Sum up all item bonuses
             foreach (var item in EquippedItems)
@@ -137,26 +155,212 @@ namespace SampleProj.Controllers
                 bonus_spellvamp_total += item.SpellVampBonus;
                 bonus_tenacity_total += item.TenacityBonus;
                 bonus_omnivamp_total += item.omnivamp_bonus;
-                bonus_slow_res_total += item.slow_res_bonus;
                 bonus_ap_total += item.bonus_ap;
                 bonus_ap_amp_total += item.bonus_ap_amp;
                 bonus_MS_amp_total += item.bonus_MS_amp;
                 bonus_lethality_total += item.bonus_lethality;
                 bonus_magic_pen_total += item.bonus_magic_pen;
-                bonus_percent_MR_pen_total += item.bonus_percent_MR_pen;
-                bonus_percent_AR_pen_total += item.bonus_percent_AR_pen;
                 bonus_ability_haste_total += item.bonus_ability_haste;
-                bonus_gold_generation += item.bonus_gold_generation;
+                bonus_gold_generation_total += item.bonus_gold_generation;
+
+                // Multiplicative stacking is used to calculate these percentages.
+                // For example, if we have 3 items with 0.1, 0.2, 0.15 percent MR pen,
+                // then the total reduction will be (1-0.1)*(1-0.2)*(1-0.15) = 0.612
+                // not 0.55
+                // 
+                // To calculate the final percent, for each item j, compute
+                // current bonus = current bonus * (1 - j)
+                // for all j
+                //
+                // then, we have the multiplier for MR after applying the percent reductions.
+                // To get the percent penetration, subtract this from 1.
+                bonus_percent_MR_pen_total *= (1 - item.bonus_percent_MR_pen);
+                bonus_percent_AR_pen_total *= (1 - item.bonus_percent_AR_pen);
+                bonus_slow_res_total *= (1 - item.slow_res_bonus);
             }
+
 
             // Compute final stats
 
             // Health computation
-            // HP = Base HP + Bonus HP + (Level * HP Growth)
+            // HP = Base HP + Bonus HP + ((Level-1) * HP Growth)
             ChampStat.Health = base_stats.base_HP + HP_bonus_total
-                               + ChampStat.Level * base_stats.HP_growth;
+                               + ((ChampStat.Level - 1) * base_stats.HP_growth);
 
+            // Health regen computation
+            // HP5 = Base HP5 + Bonus HP5 + ((Level-1) * HP5 growth)
+            ChampStat.HealthRegeneration = base_stats.base_HP_regen + HP5_bonus_total
+                                           + ((ChampStat.Level-1) * base_stats.HP_regen_growth);
 
+            // Heal + Shield power computation
+            // Heal/Shield power is just equal to the bonus.
+            ChampStat.heal_shield_power = bonus_H_S_power_total;
+
+            // Mana computation
+            // Mana = Base mana + Bonus mana + ((Level-1) * Mana growth)
+            ChampStat.Mana = base_stats.base_mana + bonus_mana_total
+                             + ((ChampStat.Level - 1) * base_stats.mana_growth);
+
+            // Mana regen computation
+            // Mana regen = Base mana regen + Bonus mana regen + ((Level-1) * Mana regen growth)
+            ChampStat.ManaRegeneration = base_stats.base_mana_regen + bonus_mana_regen_total
+                                         + ((ChampStat.Level-1) * base_stats.mana_regen_growth);
+
+            // AD computation
+            // AD = Base AD + Bonus AD + ((Level-1) * AD Growth)
+            ChampStat.AttackDamage = base_stats.base_AD + bonus_AD_total
+                                     + ((ChampStat.Level - 1) * base_stats.AD_growth);
+
+            // AS computation
+            // Attack speed is calculated using a ratio, which is specific to the champion.
+            // AS = AS Ratio * ((base AS / AS Ratio) + bonus AS + ((Level-1) * AS Growth))
+            // where bonus AS, base AS, and AS ratio are expressed as decimal percentages.
+            //
+            // Bonus AS here is from the items, but in the canonical calculation is also
+            // from growth, which is why this formula may look different
+            ChampStat.AttackSpeed = ((base_stats.base_AS / base_stats.AS_ratio) + bonus_AS_total
+                                    + ((ChampStat.Level - 1) * base_stats.AS_growth))
+                                    * base_stats.AS_ratio;
+
+            // Range computation
+            // Range = Base range + bonus range
+            ChampStat.AttackRange = base_stats.range + bonus_range_total;
+
+            // Armor computation
+            // Armor = base armor + bonus armor + ((Level-1) * armor growth)
+            ChampStat.Armor = base_stats.base_armor + bonus_armor_total
+                              + ((ChampStat.Level - 1) * base_stats.armor_growth);
+
+            // MR Computation
+            // MR = base MR + bonus MR + ((Level-1) * MR growth)
+            ChampStat.MagicResistance = base_stats.base_MR + bonus_MR_total
+                                        + ((ChampStat.Level - 1) * base_stats.MR_growth);
+
+            // MS Computation
+            // Movement speed is calculated first as a raw speed, then reduced by a 
+            // ratio based on the magnitude of the raw value.
+            //
+            // Thankfully, multiplicative movement speed boosts are rare and usually on
+            // stuff like ghost, or item actives like Mercurial scimitar.
+            // These are ignored for these calculations as they are out of scope of the project.
+
+            // Calculate MS_raw = (Base MS + Bonus MS)*(1+Bonus MS Amp)
+            double MS_raw = (base_stats.base_MS + bonus_MS_total) * (1 + bonus_MS_amp_total);
+
+            // Calculate movement speed after scaling
+            if (MS_raw <= 415)
+            {
+                // There is no scaling if MS_raw is less than 415
+                ChampStat.MovementSpeed = MS_raw;
+            }
+            else if (415 < MS_raw && MS_raw <= 490)
+            {
+                // Scale the portion above 415 by 0.8
+                ChampStat.MovementSpeed = ((MS_raw - 415) * 0.8) + 415;
+
+            }
+            else if (490 < MS_raw)
+            {
+                // Scale the portion above 490 by 0.5
+                // Scale the portion above 415 till 490 by 0.8
+                ChampStat.MovementSpeed = ((MS_raw - 490) * 0.5) + ((490 - 415) * 0.8) + 415;
+
+            }
+            // Error! If you see MS = -1 something has gone wrong!
+            else 
+            {
+                ChampStat.MovementSpeed = -1;
+            }
+
+            // Crit chance computation
+            // Crit chance is only based on the items equipt
+            ChampStat.CriticalStrikeChance = bonus_crit_chance_total;
+
+            // Crit damage computation
+            // Crit damage starts at a base of 1.75 and is only increased by items (infinity edge)
+            ChampStat.CriticalStrikeDamage = 1.75 + bonus_crit_dmg_total;
+
+            // Lifesteal computation
+            // Lifesteal is only based on the items equipt (since we do not consider runes, abilities)
+            ChampStat.LifeSteal = bonus_lifesteal_total;
+
+            // Spellvamp computation
+            // Spellvamp is only based on items
+            ChampStat.SpellVamp = bonus_spellvamp_total;
+
+            // Omnivamp computation
+            // Omnivamp is only based on items
+            ChampStat.Omnivamp = bonus_omnivamp_total;
+
+            // Tenacity computation
+            // While the tenacity computation is normally complicated, our case
+            // is simplified as only merc treads has tenacity as a stat, the rest
+            // are from item actives, abilities, or consumables which are not
+            // to be considered.
+            //
+            // Therefore, set the tenacity based on the sum of it's bonus total,
+            // since there is only one possible item that increases this anyways.
+
+            ChampStat.Tenacity = bonus_tenacity_total;
+
+            // Slow resist computation
+            // We now subtract by 1 to undo our above multiplications by (1-j)
+
+            ChampStat.slow_resist = (1-bonus_slow_res_total);
+
+            // Energy computation
+            // Energy is not influenced by any items
+
+            ChampStat.energy = base_stats.base_energy;
+
+            // Energy regen computation
+            // Energy regen is only affected by abilities, a rune, and blue buff.
+
+            ChampStat.energy_regen = base_stats.base_energy_regen;
+
+            // Ability haste computation
+            // Haste only really stacks off item stats, and is additive.
+            // 
+            // In the future if wanted we can display the CDR provided, which is
+            // (Haste/(Haste + 100) * 100).
+            // This could be done outside of this function however.
+
+            ChampStat.ability_haste = bonus_ability_haste_total;
+
+            // AP computation
+            // AP has no base stats, however, deathcap multiplies this number.
+            // Actually, so does demonic embrace, however implementing this would
+            // make things messy as the value would need to be stored different to
+            // the deathcap amp, and would require using an if statement to
+            // check through the item being presented to see if it is demonic before
+            // altering computation.
+            //
+            // To keep things simple, we can just ignore the item passive there as it is
+            // not important for the scope of the project. Deathcap is much more meaningful.
+
+            ChampStat.ability_power = bonus_ap_total * (1 + bonus_ap_amp_total);
+
+            // magic penetration computation
+            // magic penetration is just additive from items (and runes, which we dont include)
+
+            ChampStat.magic_pen = bonus_magic_pen_total;
+
+            // percent magic pen computation
+            // Compute (1-total) as defined in the for loop above.
+            ChampStat.percent_MR_pen = (1 - bonus_percent_MR_pen_total);
+
+            // armor penetration computation
+            // This is calculated directly from lethality, but is not 1 to 1
+            // Armor pen = lethality * (0.6 + 0.4 * level/18)
+            ChampStat.armor_penetration = (bonus_lethality_total) * (0.6 + (0.4 * ChampStat.Level) / 18);
+
+            // percent armor pen computation
+            // This is also computed multiplicatively, details are above in the for loop.
+            ChampStat.percent_AR_pen = (1 - bonus_percent_AR_pen_total);
+
+            // Gold generation computation
+            // This is additive, and simple enough.
+            ChampStat.gold_generation = base_stats.base_gold_generation + bonus_gold_generation_total;
 
 
 

--- a/Main/Controllers/ItemsController.cs
+++ b/Main/Controllers/ItemsController.cs
@@ -32,10 +32,14 @@ namespace SampleProj.Controllers
                 new Item(),
                 new Item()
             };
-            AvailableItems[0].Name = "Health Potion";
-            AvailableItems[0].HealthBonus = 50;
-            AvailableItems[1].Name = "Sword"; 
-            AvailableItems[1].AttackDamageBonus = 10;
+            AvailableItems[0].Name = "Test_Item_1";
+            AvailableItems[0].HealthBonus = 50d;
+            AvailableItems[0].HealthRegenerationBonus = 3.2d;
+            AvailableItems[1].Name = "Test_Item_2"; 
+            AvailableItems[1].HealthBonus = 14d;
+
+
+
             AvailableItems[2].Name = "Iron Helm"; 
             AvailableItems[2].ArmorBonus = 20;
             AvailableItems[3].Name = "Magical Ring";  
@@ -54,17 +58,112 @@ namespace SampleProj.Controllers
             AvailableItems[9].CriticalStrikeChanceBonus =0.2;
             EquippedItems = new List<Item>();
             ChampStat= new ChampionStat();
+            // FOR TESTING PURPOSES
+            EquippedItems.Add(AvailableItems[0]);
+            // FOR TESTING PURPOSES
             ViewBag.availableItems = AvailableItems;
             ViewBag.equippedItems = EquippedItems;
         }
 
         public IActionResult Index(Champion champ)
         {
+            // set the new champion data to be part of the current stat calculation.
             ChampStat.ChampionData=champ;
             //setting the ViewBag
             ViewBag.availableItems = AvailableItems;
-            ViewBag.equippedItems = EquippedItems; 
+            ViewBag.equippedItems = EquippedItems;
+
+            calculate_stats();
             return View("Index",ChampStat);
         }
+
+
+        // internal function to calculate the current champion statistic breakdown
+        private void calculate_stats()
+        {
+            // Reset ChampStat to the base state.
+            ChampStat.clear();
+
+            // grab reference to the base stats
+            Champion? base_stats = ChampStat.ChampionData;
+
+            // stat totals, to be summed up across all items
+            double HP_bonus_total = 0d;
+            double HP5_bonus_total = 0d;
+            double bonus_H_S_power_total = 0d;
+            double bonus_mana_total = 0d;
+            double bonus_mana_regen_total = 0d;
+            double bonus_AD_total = 0d;
+            double bonus_AS_total = 0d;
+            int bonus_range_total = 0;
+            double bonus_armor_total = 0d;
+            double bonus_MR_total = 0d;
+            double bonus_MS_total = 0d;
+            double bonus_crit_chance_total = 0d;
+            double bonus_crit_dmg_total = 0d;
+            double bonus_lifesteal_total = 0d;
+            double bonus_spellvamp_total = 0d;
+            double bonus_tenacity_total = 0d;
+            double bonus_omnivamp_total = 0d;
+            double bonus_slow_res_total = 0d;
+            double bonus_ap_total = 0d;
+            double bonus_ap_amp_total = 0d;
+            double bonus_MS_amp_total = 0d;
+            int bonus_lethality_total = 0;
+            int bonus_magic_pen_total = 0;
+            double bonus_percent_MR_pen_total = 0d;
+            double bonus_percent_AR_pen_total = 0d;
+            double bonus_ability_haste_total = 0d;
+            int bonus_gold_generation = 0;
+
+            // Sum up all item bonuses
+            foreach (var item in EquippedItems)
+            {
+                // Add each bonus stat
+                HP_bonus_total += item.HealthBonus;
+                HP5_bonus_total += item.HealthRegenerationBonus;
+                bonus_H_S_power_total += item.bonus_heal_shield_power;
+                bonus_mana_total += item.ManaBonus;
+                bonus_mana_regen_total += item.ManaRegenerationBonus;
+                bonus_AD_total += item.AttackDamageBonus;
+                bonus_AS_total += item.AttackSpeedBonus;
+                bonus_range_total += item.AttackRangeBonus;
+                bonus_armor_total += item.ArmorBonus;
+                bonus_MR_total += item.MagicResistanceBonus;
+                bonus_MS_total += item.MovementSpeedBonus;
+                bonus_crit_chance_total += item.CriticalStrikeChanceBonus;
+                bonus_crit_dmg_total += item.CriticalStrikeDamageBonus;
+                bonus_lifesteal_total += item.LifeStealBonus;
+                bonus_spellvamp_total += item.SpellVampBonus;
+                bonus_tenacity_total += item.TenacityBonus;
+                bonus_omnivamp_total += item.omnivamp_bonus;
+                bonus_slow_res_total += item.slow_res_bonus;
+                bonus_ap_total += item.bonus_ap;
+                bonus_ap_amp_total += item.bonus_ap_amp;
+                bonus_MS_amp_total += item.bonus_MS_amp;
+                bonus_lethality_total += item.bonus_lethality;
+                bonus_magic_pen_total += item.bonus_magic_pen;
+                bonus_percent_MR_pen_total += item.bonus_percent_MR_pen;
+                bonus_percent_AR_pen_total += item.bonus_percent_AR_pen;
+                bonus_ability_haste_total += item.bonus_ability_haste;
+                bonus_gold_generation += item.bonus_gold_generation;
+            }
+
+            // Compute final stats
+
+            // Health computation
+            // HP = Base HP + Bonus HP + (Level * HP Growth)
+            ChampStat.Health = base_stats.base_HP + HP_bonus_total
+                               + ChampStat.Level * base_stats.HP_growth;
+
+
+
+
+
+        }
+
+
+
+
     }
 }

--- a/Main/Models/Champion.cs
+++ b/Main/Models/Champion.cs
@@ -61,7 +61,8 @@ namespace SampleProj.Models
 
         // Other statistics
         public int range { get; set; }
-        public int base_MS { get; set; }
+        public double base_MS { get; set; }
+        public int base_gold_generation {  get; set; } 
 
 
     }

--- a/Main/Models/Champion.cs
+++ b/Main/Models/Champion.cs
@@ -63,6 +63,7 @@ namespace SampleProj.Models
         public int range { get; set; }
         public double base_MS { get; set; }
         public int base_gold_generation {  get; set; } 
+        public double AS_ratio { get; set; }
 
 
     }

--- a/Main/Models/Items.cs
+++ b/Main/Models/Items.cs
@@ -7,17 +7,17 @@ namespace SampleProj.Models
         public class Item
     {
         public string? Name { get; set; }
-        public int HealthBonus { get; set; }                //HP
+        public double HealthBonus { get; set; }                //HP
         public double HealthRegenerationBonus { get; set; }     // HP5
         public double bonus_heal_shield_power { get; set; }      // for support items
-        public int ManaBonus { get; set; }                      // MP
+        public double ManaBonus { get; set; }                      // MP
         public double ManaRegenerationBonus { get; set; }       // MP5
-        public int AttackDamageBonus { get; set; }              // AD
+        public double AttackDamageBonus { get; set; }              // AD
         public double AttackSpeedBonus { get; set; }            // AS (attacks per second)
         public int AttackRangeBonus { get; set; }               // rang
-        public int ArmorBonus { get; set; }                     // AR
-        public int MagicResistanceBonus { get; set; }           // MR
-        public int MovementSpeedBonus { get; set; }             // MS
+        public double ArmorBonus { get; set; }                     // AR
+        public double MagicResistanceBonus { get; set; }           // MR
+        public double MovementSpeedBonus { get; set; }             // MS
         public double CriticalStrikeChanceBonus { get; set; }   // Crit
         public double CriticalStrikeDamageBonus { get; set; }  // CritDmg
         public double LifeStealBonus { get; set; }              // LS
@@ -28,40 +28,42 @@ namespace SampleProj.Models
         public double bonus_ap { get; set; }                    // ability power
         public double bonus_ap_amp { get; set; }                // AP amp, so, deathcap
         public double bonus_MS_amp { get; set; }                // amp to movement speed
-        public double bonus_lethality { get; set; }
-        public double bonus_magic_pen { get; set; }
+        public int bonus_lethality { get; set; }
+        public int bonus_magic_pen { get; set; }
         public double bonus_percent_MR_pen { get; set; }
         public double bonus_percent_AR_pen { get; set; }
         public double bonus_ability_haste { get; set; }
+        public int bonus_gold_generation {  get; set; }
 
     public Item(){
             Name="";
-            HealthBonus=0;
-            HealthRegenerationBonus=0;
-            bonus_heal_shield_power = 0;
-            ManaBonus =0;
-            ManaRegenerationBonus=0;
-            AttackDamageBonus=0;
-            AttackSpeedBonus=0;
+            HealthBonus=0d;
+            HealthRegenerationBonus=0d;
+            bonus_heal_shield_power = 0d;
+            ManaBonus =0d;
+            ManaRegenerationBonus=0d;
+            AttackDamageBonus=0d;
+            AttackSpeedBonus=0d;
             AttackRangeBonus=0;
-            ArmorBonus=0;
-            MagicResistanceBonus=0;
-            MovementSpeedBonus=0;
-            CriticalStrikeChanceBonus=0;
-            CriticalStrikeDamageBonus=0;
-            LifeStealBonus=0;
-            SpellVampBonus=0;
-            TenacityBonus=0;
-            omnivamp_bonus = 0;
-            slow_res_bonus = 0;
-            bonus_ap = 0;
-            bonus_ap_amp = 0;
-            bonus_MS_amp = 0;
+            ArmorBonus=0d;
+            MagicResistanceBonus=0d;
+            MovementSpeedBonus=0d;
+            CriticalStrikeChanceBonus=0d;
+            CriticalStrikeDamageBonus=0d;
+            LifeStealBonus=0d;
+            SpellVampBonus=0d;
+            TenacityBonus=0d;
+            omnivamp_bonus = 0d;
+            slow_res_bonus = 0d;
+            bonus_ap = 0d;
+            bonus_ap_amp = 0d;
+            bonus_MS_amp = 0d;
             bonus_lethality = 0;
             bonus_magic_pen = 0;
-            bonus_percent_MR_pen = 0;
-            bonus_percent_AR_pen = 0;
-            bonus_ability_haste = 0;
+            bonus_percent_MR_pen = 0d;
+            bonus_percent_AR_pen = 0d;
+            bonus_ability_haste = 0d;
+            bonus_gold_generation = 0;
         }
     }
 
@@ -72,8 +74,8 @@ namespace SampleProj.Models
     // Health,HealthRegeneration,..., in ChampionStat
     public class ChampionStat
     {
-        //Until either the database or API get up and running, this will just be temporary to see how things look
         public Champion? ChampionData { get; set; }                 // The Champion
+        public int Level { get; set; }                        // Current level
         public double Health { get; set; }                    // HP
         public double HealthRegeneration { get; set; }     // HP5
         public double heal_shield_power { get; set; }      // for support items
@@ -96,63 +98,77 @@ namespace SampleProj.Models
         public double energy_regen {  get; set; }
         public double ability_haste {  get; set; }        // CDR/Ability Haste
         public double ability_power { get; set; }         // AP
-        public double magic_pen {  get; set; }            // AP lethality
+        public int magic_pen {  get; set; }            // AP lethality
         public double percent_MR_pen {  get; set; }       // MR pen %
-        public double lethality {  get; set; }            // lethality
+        public int lethality {  get; set; }            // lethality
         public double percent_AR_pen { get; set; }        // armor pen %
         public int gold_generation { get; set; }          // gold gained per second
 
 
         public ChampionStat(){
             ChampionData= new Champion();
-            Health = 550;
-            HealthRegeneration = 8.0;
-            Mana = 350;
-            ManaRegeneration = 6.0;
-            AttackDamage = 60;
-            AttackSpeed = 0.7;
-            AttackRange = 175;
-            Armor = 30;
-            MagicResistance = 30;
-            MovementSpeed = 345;
-            CriticalStrikeChance = 0.25;
-            CriticalStrikeDamage = 200;
+            Level = 1;
+            Health = 0d;
+            heal_shield_power = 0d;
+            HealthRegeneration = 0d;
+            Mana = 0d;
+            ManaRegeneration = 0d;
+            AttackDamage = 0d;
+            AttackSpeed = 0d;
+            AttackRange = 0;
+            Armor = 0d;
+            MagicResistance = 0d;
+            MovementSpeed = 0d;
+            CriticalStrikeChance = 0d;
+            CriticalStrikeDamage = 0d;
             LifeSteal = 0d;
             SpellVamp = 0d;
+            Omnivamp = 0d;
             Tenacity = 0d;
-            energy = 200;
+            slow_resist = 0d;
+            energy = 0d;
+            energy_regen = 0d;
+            ability_haste = 0d;
+            ability_power = 0d;
+            magic_pen = 0;
+            percent_MR_pen = 0d;
+            lethality = 0;
+            percent_AR_pen = 0d;
+            gold_generation = 0;
         }
 
-        public void calculate_stats() 
+        // clear all values but retain champion data
+        public void clear()
         {
-            // Call calculation for HP
-
-            // Call calculation for HP regen
-
-            // Call calculation for mana
-
-            // Call calculation for mana regen
-
-            // Call calculation for energy/resource
-
-            // Call calculation for energy/resource regen
-
-            // Call calculation for AD
-
-            // Call calculation for AS
-
-            // Call calculation for AP
-
-            // Call calculation for Cooldown reduction
-
-            // Call calculation for Armor
-
-            // Call calculation for MR
-
-
-
-
+            Health = 0d;
+            heal_shield_power = 0d;
+            HealthRegeneration = 0d;
+            Mana = 0d;
+            ManaRegeneration = 0d;
+            AttackDamage = 0d;
+            AttackSpeed = 0d;
+            AttackRange = 0;
+            Armor = 0d;
+            MagicResistance = 0d;
+            MovementSpeed = 0d;
+            CriticalStrikeChance = 0d;
+            CriticalStrikeDamage = 0d;
+            LifeSteal = 0d;
+            SpellVamp = 0d;
+            Omnivamp = 0d;
+            Tenacity = 0d;
+            slow_resist = 0d;
+            energy = 0d;
+            energy_regen = 0d;
+            ability_haste = 0d;
+            ability_power = 0d;
+            magic_pen = 0;
+            percent_MR_pen = 0d;
+            lethality = 0;
+            percent_AR_pen = 0d;
+            gold_generation = 0;
         }
+
     }
 
 

--- a/Main/Models/Items.cs
+++ b/Main/Models/Items.cs
@@ -1,4 +1,6 @@
+using Microsoft.Identity.Client;
 using System;
+using System.Security.Permissions;
 
 namespace SampleProj.Models
 {
@@ -7,11 +9,12 @@ namespace SampleProj.Models
         public string? Name { get; set; }
         public int HealthBonus { get; set; }                //HP
         public double HealthRegenerationBonus { get; set; }     // HP5
+        public double bonus_heal_shield_power { get; set; }      // for support items
         public int ManaBonus { get; set; }                      // MP
         public double ManaRegenerationBonus { get; set; }       // MP5
         public int AttackDamageBonus { get; set; }              // AD
         public double AttackSpeedBonus { get; set; }            // AS (attacks per second)
-        public int AttackRangeBonus { get; set; }               // AR
+        public int AttackRangeBonus { get; set; }               // rang
         public int ArmorBonus { get; set; }                     // AR
         public int MagicResistanceBonus { get; set; }           // MR
         public int MovementSpeedBonus { get; set; }             // MS
@@ -20,13 +23,23 @@ namespace SampleProj.Models
         public double LifeStealBonus { get; set; }              // LS
         public double SpellVampBonus { get; set; }              // SV
         public double TenacityBonus { get; set; }              // Tenacity
-        public int EnergyBonus { get; set; }                   // Energy
+        public double omnivamp_bonus { get; set; }
+        public double slow_res_bonus { get; set; }
+        public double bonus_ap { get; set; }                    // ability power
+        public double bonus_ap_amp { get; set; }                // AP amp, so, deathcap
+        public double bonus_MS_amp { get; set; }                // amp to movement speed
+        public double bonus_lethality { get; set; }
+        public double bonus_magic_pen { get; set; }
+        public double bonus_percent_MR_pen { get; set; }
+        public double bonus_percent_AR_pen { get; set; }
+        public double bonus_ability_haste { get; set; }
 
-        public Item(){
+    public Item(){
             Name="";
             HealthBonus=0;
             HealthRegenerationBonus=0;
-            ManaBonus=0;
+            bonus_heal_shield_power = 0;
+            ManaBonus =0;
             ManaRegenerationBonus=0;
             AttackDamageBonus=0;
             AttackSpeedBonus=0;
@@ -39,30 +52,57 @@ namespace SampleProj.Models
             LifeStealBonus=0;
             SpellVampBonus=0;
             TenacityBonus=0;
-            EnergyBonus=0;
+            omnivamp_bonus = 0;
+            slow_res_bonus = 0;
+            bonus_ap = 0;
+            bonus_ap_amp = 0;
+            bonus_MS_amp = 0;
+            bonus_lethality = 0;
+            bonus_magic_pen = 0;
+            bonus_percent_MR_pen = 0;
+            bonus_percent_AR_pen = 0;
+            bonus_ability_haste = 0;
         }
     }
 
+    // the current representation of the stat calculation
+    //
+    // take the base data from ChampionData, and the item
+    // information, then calculate the final values for
+    // Health,HealthRegeneration,..., in ChampionStat
     public class ChampionStat
     {
         //Until either the database or API get up and running, this will just be temporary to see how things look
-        public Champion? ChampionData {get;set;}                 // The Champion
-        public int Health { get; set; }                    // HP
+        public Champion? ChampionData { get; set; }                 // The Champion
+        public double Health { get; set; }                    // HP
         public double HealthRegeneration { get; set; }     // HP5
-        public int Mana { get; set; }                      // MP
+        public double heal_shield_power { get; set; }      // for support items
+        public double Mana { get; set; }                      // MP
         public double ManaRegeneration { get; set; }       // MP5
-        public int AttackDamage { get; set; }              // AD
+        public double AttackDamage { get; set; }              // AD
         public double AttackSpeed { get; set; }            // AS (attacks per second)
         public int AttackRange { get; set; }               // AR
-        public int Armor { get; set; }                     // AR
-        public int MagicResistance { get; set; }           // MR
-        public int MovementSpeed { get; set; }             // MS
+        public double Armor { get; set; }                     // AR
+        public double MagicResistance { get; set; }           // MR
+        public double MovementSpeed { get; set; }             // MS
         public double CriticalStrikeChance { get; set; }   // Crit
         public double CriticalStrikeDamage { get; set; }  // CritDmg
         public double LifeSteal { get; set; }              // LS
         public double SpellVamp { get; set; }              // SV
+        public double Omnivamp {  get; set; }               // omnivamp
         public double Tenacity { get; set; }              // Tenacity
-        public int Energy { get; set; }                   // Energy
+        public double slow_resist {  get; set; }          // slow resist
+        public double energy { get; set; }                // Energy
+        public double energy_regen {  get; set; }
+        public double ability_haste {  get; set; }        // CDR/Ability Haste
+        public double ability_power { get; set; }         // AP
+        public double magic_pen {  get; set; }            // AP lethality
+        public double percent_MR_pen {  get; set; }       // MR pen %
+        public double lethality {  get; set; }            // lethality
+        public double percent_AR_pen { get; set; }        // armor pen %
+        public int gold_generation { get; set; }          // gold gained per second
+
+
         public ChampionStat(){
             ChampionData= new Champion();
             Health = 550;
@@ -77,10 +117,41 @@ namespace SampleProj.Models
             MovementSpeed = 345;
             CriticalStrikeChance = 0.25;
             CriticalStrikeDamage = 200;
-            LifeSteal = 0.1;
-            SpellVamp = 0.1;
-            Tenacity = 0.2;
-            Energy = 200;
+            LifeSteal = 0d;
+            SpellVamp = 0d;
+            Tenacity = 0d;
+            energy = 200;
+        }
+
+        public void calculate_stats() 
+        {
+            // Call calculation for HP
+
+            // Call calculation for HP regen
+
+            // Call calculation for mana
+
+            // Call calculation for mana regen
+
+            // Call calculation for energy/resource
+
+            // Call calculation for energy/resource regen
+
+            // Call calculation for AD
+
+            // Call calculation for AS
+
+            // Call calculation for AP
+
+            // Call calculation for Cooldown reduction
+
+            // Call calculation for Armor
+
+            // Call calculation for MR
+
+
+
+
         }
     }
 

--- a/Main/Models/Items.cs
+++ b/Main/Models/Items.cs
@@ -28,7 +28,7 @@ namespace SampleProj.Models
         public double bonus_ap { get; set; }                    // ability power
         public double bonus_ap_amp { get; set; }                // AP amp, so, deathcap
         public double bonus_MS_amp { get; set; }                // amp to movement speed
-        public int bonus_lethality { get; set; }
+        public int bonus_lethality { get; set; }                // used to calculate flat AR pen
         public int bonus_magic_pen { get; set; }
         public double bonus_percent_MR_pen { get; set; }
         public double bonus_percent_AR_pen { get; set; }
@@ -100,10 +100,18 @@ namespace SampleProj.Models
         public double ability_power { get; set; }         // AP
         public int magic_pen {  get; set; }            // AP lethality
         public double percent_MR_pen {  get; set; }       // MR pen %
-        public int lethality {  get; set; }            // lethality
+        public double armor_penetration {  get; set; }            // lethality
         public double percent_AR_pen { get; set; }        // armor pen %
         public int gold_generation { get; set; }          // gold gained per second
 
+        // At some point, we might want to have a function defined
+        //
+        // public ChampionStat(Champion this_champion)...
+        //
+        // which sets ChampionData to this_champion
+        //
+        // this could be useful in the future when something needs changing so I will
+        // leave this note here.
 
         public ChampionStat(){
             ChampionData= new Champion();
@@ -132,7 +140,7 @@ namespace SampleProj.Models
             ability_power = 0d;
             magic_pen = 0;
             percent_MR_pen = 0d;
-            lethality = 0;
+            armor_penetration = 0d;
             percent_AR_pen = 0d;
             gold_generation = 0;
         }
@@ -164,7 +172,7 @@ namespace SampleProj.Models
             ability_power = 0d;
             magic_pen = 0;
             percent_MR_pen = 0d;
-            lethality = 0;
+            armor_penetration = 0d;
             percent_AR_pen = 0d;
             gold_generation = 0;
         }

--- a/Main/Views/Champions/Index.cshtml
+++ b/Main/Views/Champions/Index.cshtml
@@ -12,7 +12,7 @@
         <div class="champion-card">
             <!-- The URL will become shorter once we get the API/Database setup, but as of right now, data will be pass through the URL-->
             <a style="text-decoration: none;"href="@Url.Action("Index", "Items", new { Id =@champion.Id, Name=@champion.Name,
-             Category=@champion.Category, ImageUrl=@champion.ImageUrl })">
+             Category=@champion.Category, ImageUrl=@champion.ImageUrl, base_HP_regen=2.0})">
                 <img src="@champion.ImageUrl" alt="@champion.Name" width="500" height="500" />
                 <h2>@champion.Name</h2>
                 <p>Category: @champion.Category</p>

--- a/Main/Views/Items/Index.cshtml
+++ b/Main/Views/Items/Index.cshtml
@@ -1,4 +1,4 @@
-@* Items.cshtml file. Located in Views/Champions *@
+@* Items.cshtml file. Located in Views/Items *@
 @{
     Layout = "_Layout1"; // Specify the layout file you want to use
 }
@@ -90,7 +90,7 @@
     </tr>
     <tr>
         <th>Energy</th>
-        <td>@Model.Energy</td>
+        <td>@Model.energy</td>
     </tr>
 </table>
 


### PR DESCRIPTION
I have created the function calculate_stats to compute the current representation of the statistical breakdown for the currently selected champion given the currently held items. There are also some changes to how the bonus stats are calculated to reflect the multiplicative nature of some statistics, changes to statistic datatypes, among other things. Everything should be explained sufficiently in comments.